### PR TITLE
Fix HTML for navigation links

### DIFF
--- a/accessor-method-slot-definition-standard-accessor-method.html
+++ b/accessor-method-slot-definition-standard-accessor-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 

--- a/accessor-method-slot-definition-standard-accessor-method.html
+++ b/accessor-method-slot-definition-standard-accessor-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 
 <A NAME="accessor-method-slot-definition"><I>Method</I> <B>ACCESSOR-METHOD-SLOT-DEFINITION</B>

--- a/accessor-method-slot-definition.html
+++ b/accessor-method-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="accessor-method-slot-definition"><I>Generic Function</I> <B>ACCESSOR-METHOD-SLOT-DEFINITION</B>

--- a/accessor-method-slot-definition.html
+++ b/accessor-method-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="accessor-method-slot-definition"><I>Generic Function</I> <B>ACCESSOR-METHOD-SLOT-DEFINITION</B>
 

--- a/add-dependent-funcallable-standard-class.html
+++ b/add-dependent-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-dependent"><I>Method</I> <B>ADD-DEPENDENT</B>
 

--- a/add-dependent-funcallable-standard-class.html
+++ b/add-dependent-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-dependent"><I>Method</I> <B>ADD-DEPENDENT</B>

--- a/add-dependent-standard-class.html
+++ b/add-dependent-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-dependent"><I>Method</I> <B>ADD-DEPENDENT</B>
 

--- a/add-dependent-standard-class.html
+++ b/add-dependent-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-dependent"><I>Method</I> <B>ADD-DEPENDENT</B>

--- a/add-dependent-standard-generic-function.html
+++ b/add-dependent-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-dependent"><I>Method</I> <B>ADD-DEPENDENT</B>
 

--- a/add-dependent-standard-generic-function.html
+++ b/add-dependent-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-dependent"><I>Method</I> <B>ADD-DEPENDENT</B>

--- a/add-dependent.html
+++ b/add-dependent.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-dependent"><I>Generic Function</I> <B>ADD-DEPENDENT</B>

--- a/add-dependent.html
+++ b/add-dependent.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-dependent"><I>Generic Function</I> <B>ADD-DEPENDENT</B>
 

--- a/add-direct-method-class.html
+++ b/add-direct-method-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-direct-method"><I>Method</I> <B>ADD-DIRECT-METHOD</B>

--- a/add-direct-method-class.html
+++ b/add-direct-method-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-direct-method"><I>Method</I> <B>ADD-DIRECT-METHOD</B>
 

--- a/add-direct-method-eql-specializer.html
+++ b/add-direct-method-eql-specializer.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-direct-method"><I>Method</I> <B>ADD-DIRECT-METHOD</B>

--- a/add-direct-method-eql-specializer.html
+++ b/add-direct-method-eql-specializer.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-direct-method"><I>Method</I> <B>ADD-DIRECT-METHOD</B>
 

--- a/add-direct-method.html
+++ b/add-direct-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-direct-method"><I>Generic Function</I> <B>ADD-DIRECT-METHOD</B>

--- a/add-direct-method.html
+++ b/add-direct-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-direct-method"><I>Generic Function</I> <B>ADD-DIRECT-METHOD</B>
 

--- a/add-direct-subclass-class-class.html
+++ b/add-direct-subclass-class-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-direct-subclass"><I>Method</I> <B>ADD-DIRECT-SUBCLASS</B>
 

--- a/add-direct-subclass-class-class.html
+++ b/add-direct-subclass-class-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-direct-subclass"><I>Method</I> <B>ADD-DIRECT-SUBCLASS</B>

--- a/add-direct-subclass.html
+++ b/add-direct-subclass.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-direct-subclass"><I>Generic Function</I> <B>ADD-DIRECT-SUBCLASS</B>
 

--- a/add-direct-subclass.html
+++ b/add-direct-subclass.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-direct-subclass"><I>Generic Function</I> <B>ADD-DIRECT-SUBCLASS</B>

--- a/add-method-standard-generic-function-standard-method.html
+++ b/add-method-standard-generic-function-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-method"><I>Method</I> <B>ADD-METHOD</B>

--- a/add-method-standard-generic-function-standard-method.html
+++ b/add-method-standard-generic-function-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-method"><I>Method</I> <B>ADD-METHOD</B>
 

--- a/add-method.html
+++ b/add-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="add-method"><I>Generic Function</I> <B>ADD-METHOD</B>
 

--- a/add-method.html
+++ b/add-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="add-method"><I>Generic Function</I> <B>ADD-METHOD</B>

--- a/all-no-methods.html
+++ b/all-no-methods.html
@@ -1,5 +1,7 @@
 <HTML>
 <HEAD>
+<title>Index of all functions excluding methods</title>
+<link rel="stylesheet" href="clos-mop.css">
 </HEAD>
 <BODY>
 

--- a/all-no-methods.html
+++ b/all-no-methods.html
@@ -4,6 +4,11 @@
 <link rel="stylesheet" href="clos-mop.css">
 </HEAD>
 <BODY>
+<nav><ul class=navigation>
+  <li class=navigation>
+    <a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+  </li>
+</ul></nav>
 
 <p><a href="all.html"> Include methods.</a>
 Methods excluded.</p>

--- a/all.html
+++ b/all.html
@@ -4,6 +4,11 @@
 <link rel="stylesheet" href="clos-mop.css">
 </HEAD>
 <BODY>
+<nav><ul class=navigation>
+  <li class=navigation>
+    <a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+  </li>
+</ul></nav>
 
 <p>Methods included.  
 <a href="all-no-methods.html"> Exclude methods.</a></p>

--- a/all.html
+++ b/all.html
@@ -1,5 +1,7 @@
 <HTML>
 <HEAD>
+<title>Index of all functions and methods</title>
+<link rel="stylesheet" href="clos-mop.css">
 </HEAD>
 <BODY>
 

--- a/allocate-instance-built-in-class.html
+++ b/allocate-instance-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="allocate-instance"><I>Method</I> <B>ALLOCATE-INSTANCE</B>
 

--- a/allocate-instance-built-in-class.html
+++ b/allocate-instance-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="allocate-instance"><I>Method</I> <B>ALLOCATE-INSTANCE</B>

--- a/allocate-instance-funcallable-standard-class.html
+++ b/allocate-instance-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="allocate-instance"><I>Method</I> <B>ALLOCATE-INSTANCE</B>
 

--- a/allocate-instance-funcallable-standard-class.html
+++ b/allocate-instance-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="allocate-instance"><I>Method</I> <B>ALLOCATE-INSTANCE</B>

--- a/allocate-instance-standard-class.html
+++ b/allocate-instance-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="allocate-instance"><I>Method</I> <B>ALLOCATE-INSTANCE</B>
 

--- a/allocate-instance-standard-class.html
+++ b/allocate-instance-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="allocate-instance"><I>Method</I> <B>ALLOCATE-INSTANCE</B>

--- a/allocate-instance.html
+++ b/allocate-instance.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="allocate-instance"><I>Generic Function</I> <B>ALLOCATE-INSTANCE</B>
 

--- a/allocate-instance.html
+++ b/allocate-instance.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="allocate-instance"><I>Generic Function</I> <B>ALLOCATE-INSTANCE</B>

--- a/chapter-6-sections.html
+++ b/chapter-6-sections.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="readers-for-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H3>Chapter 6 Sections</H3>
 

--- a/chapter-6-sections.html
+++ b/chapter-6-sections.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="chapter-6.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="readers-for-class-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H3>Chapter 6 Sections</H3>

--- a/chapter-6.html
+++ b/chapter-6.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="dependent-maintenance-protocol.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="readers-for-class-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="dependent-maintenance-protocol.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H2>Chapter 6: Generic Functions and Methods</H2>

--- a/chapter-6.html
+++ b/chapter-6.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="readers-for-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H2>Chapter 6: Generic Functions and Methods</H2>
 

--- a/class-built-in-class.html
+++ b/class-built-in-class.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>BUILT-IN-CLASS</B>

--- a/class-built-in-class.html
+++ b/class-built-in-class.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-class.html
+++ b/class-class.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-class.html
+++ b/class-class.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>CLASS</B>

--- a/class-default-initargs-built-in-class.html
+++ b/class-default-initargs-built-in-class.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
 <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>
 

--- a/class-default-initargs-built-in-class.html
+++ b/class-default-initargs-built-in-class.html
@@ -5,14 +5,12 @@
   </HEAD>
 <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>

--- a/class-default-initargs-forward-referenced-class.html
+++ b/class-default-initargs-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>
 

--- a/class-default-initargs-forward-referenced-class.html
+++ b/class-default-initargs-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>

--- a/class-default-initargs-funcallable-standard-class.html
+++ b/class-default-initargs-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>
 

--- a/class-default-initargs-funcallable-standard-class.html
+++ b/class-default-initargs-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>

--- a/class-default-initargs-standard-class.html
+++ b/class-default-initargs-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>
 

--- a/class-default-initargs-standard-class.html
+++ b/class-default-initargs-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-default-initargs"><I>Method</I> <B>CLASS-DEFAULT-INITARGS</B>

--- a/class-default-initargs.html
+++ b/class-default-initargs.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-default-initargs"><I>Generic Function</I> <B>CLASS-DEFAULT-INITARGS</B>
 

--- a/class-default-initargs.html
+++ b/class-default-initargs.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-default-initargs"><I>Generic Function</I> <B>CLASS-DEFAULT-INITARGS</B>

--- a/class-direct-default-initargs-built-in-class.html
+++ b/class-direct-default-initargs-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>
 

--- a/class-direct-default-initargs-built-in-class.html
+++ b/class-direct-default-initargs-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>

--- a/class-direct-default-initargs-forward-referenced-class.html
+++ b/class-direct-default-initargs-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>
 

--- a/class-direct-default-initargs-forward-referenced-class.html
+++ b/class-direct-default-initargs-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>

--- a/class-direct-default-initargs-funcallable-standard-class.html
+++ b/class-direct-default-initargs-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>
 

--- a/class-direct-default-initargs-funcallable-standard-class.html
+++ b/class-direct-default-initargs-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>

--- a/class-direct-default-initargs-standard-class.html
+++ b/class-direct-default-initargs-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>
 

--- a/class-direct-default-initargs-standard-class.html
+++ b/class-direct-default-initargs-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-default-initargs"><I>Method</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>

--- a/class-direct-default-initargs.html
+++ b/class-direct-default-initargs.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-default-initargs"><I>Generic Function</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>
 

--- a/class-direct-default-initargs.html
+++ b/class-direct-default-initargs.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-default-initargs"><I>Generic Function</I> <B>CLASS-DIRECT-DEFAULT-INITARGS</B>

--- a/class-direct-slot-definition.html
+++ b/class-direct-slot-definition.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-direct-slot-definition.html
+++ b/class-direct-slot-definition.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>DIRECT-SLOT-DEFINITION</B>

--- a/class-direct-slots-built-in-class.html
+++ b/class-direct-slots-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>

--- a/class-direct-slots-built-in-class.html
+++ b/class-direct-slots-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>
 

--- a/class-direct-slots-forward-referenced-class.html
+++ b/class-direct-slots-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>

--- a/class-direct-slots-forward-referenced-class.html
+++ b/class-direct-slots-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>
 

--- a/class-direct-slots-funcallable-standard-class.html
+++ b/class-direct-slots-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>

--- a/class-direct-slots-funcallable-standard-class.html
+++ b/class-direct-slots-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>
 

--- a/class-direct-slots-standard-class.html
+++ b/class-direct-slots-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>

--- a/class-direct-slots-standard-class.html
+++ b/class-direct-slots-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-slots"><I>Method</I> <B>CLASS-DIRECT-SLOTS</B>
 

--- a/class-direct-slots.html
+++ b/class-direct-slots.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-slots"><I>Generic Function</I> <B>CLASS-DIRECT-SLOTS</B>

--- a/class-direct-slots.html
+++ b/class-direct-slots.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-slots"><I>Generic Function</I> <B>CLASS-DIRECT-SLOTS</B>
 

--- a/class-direct-subclasses-built-in-class.html
+++ b/class-direct-subclasses-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>

--- a/class-direct-subclasses-built-in-class.html
+++ b/class-direct-subclasses-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>
 

--- a/class-direct-subclasses-forward-referenced-class.html
+++ b/class-direct-subclasses-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>

--- a/class-direct-subclasses-forward-referenced-class.html
+++ b/class-direct-subclasses-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>
 

--- a/class-direct-subclasses-funcallable-standard-class.html
+++ b/class-direct-subclasses-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>

--- a/class-direct-subclasses-funcallable-standard-class.html
+++ b/class-direct-subclasses-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>
 

--- a/class-direct-subclasses-standard-class.html
+++ b/class-direct-subclasses-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>

--- a/class-direct-subclasses-standard-class.html
+++ b/class-direct-subclasses-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-subclasses"><I>Method</I> <B>CLASS-DIRECT-SUBCLASSES</B>
 

--- a/class-direct-subclasses.html
+++ b/class-direct-subclasses.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-subclasses"><I>Generic Function</I> <B>CLASS-DIRECT-SUBCLASSES</B>

--- a/class-direct-subclasses.html
+++ b/class-direct-subclasses.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-subclasses"><I>Generic Function</I> <B>CLASS-DIRECT-SUBCLASSES</B>
 

--- a/class-direct-superclasses-built-in-class.html
+++ b/class-direct-superclasses-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>
 

--- a/class-direct-superclasses-built-in-class.html
+++ b/class-direct-superclasses-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>

--- a/class-direct-superclasses-forward-referenced-class.html
+++ b/class-direct-superclasses-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>
 

--- a/class-direct-superclasses-forward-referenced-class.html
+++ b/class-direct-superclasses-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>

--- a/class-direct-superclasses-funcallable-standard-class.html
+++ b/class-direct-superclasses-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>
 

--- a/class-direct-superclasses-funcallable-standard-class.html
+++ b/class-direct-superclasses-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>

--- a/class-direct-superclasses-standard-class.html
+++ b/class-direct-superclasses-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>
 

--- a/class-direct-superclasses-standard-class.html
+++ b/class-direct-superclasses-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-superclasses"><I>Method</I> <B>CLASS-DIRECT-SUPERCLASSES</B>

--- a/class-direct-superclasses.html
+++ b/class-direct-superclasses.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-direct-superclasses"><I>Generic Function</I> <B>CLASS-DIRECT-SUPERCLASSES</B>
 

--- a/class-direct-superclasses.html
+++ b/class-direct-superclasses.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-direct-superclasses"><I>Generic Function</I> <B>CLASS-DIRECT-SUPERCLASSES</B>

--- a/class-effective-slot-definition.html
+++ b/class-effective-slot-definition.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-effective-slot-definition.html
+++ b/class-effective-slot-definition.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>EFFECTIVE-SLOT-DEFINITION</B>

--- a/class-eql-specializer.html
+++ b/class-eql-specializer.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>EQL-SPECIALIZER</B>

--- a/class-eql-specializer.html
+++ b/class-eql-specializer.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-finalization-protocol.html
+++ b/class-finalization-protocol.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="initialization-of-generic-function-and-method-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="instance-structure-protocol.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-generic-function-and-method-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="instance-structure-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 

--- a/class-finalization-protocol.html
+++ b/class-finalization-protocol.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="instance-structure-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 
 <H3>Class finalization protocol</H3>

--- a/class-finalized-p-built-in-class.html
+++ b/class-finalized-p-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>

--- a/class-finalized-p-built-in-class.html
+++ b/class-finalized-p-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>
 

--- a/class-finalized-p-forward-referenced-class.html
+++ b/class-finalized-p-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>

--- a/class-finalized-p-forward-referenced-class.html
+++ b/class-finalized-p-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>
 

--- a/class-finalized-p-funcallable-standard-class.html
+++ b/class-finalized-p-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>

--- a/class-finalized-p-funcallable-standard-class.html
+++ b/class-finalized-p-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>
 

--- a/class-finalized-p-standard-class.html
+++ b/class-finalized-p-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>

--- a/class-finalized-p-standard-class.html
+++ b/class-finalized-p-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-finalized-p"><I>Method</I> <B>CLASS-FINALIZED-P</B>
 

--- a/class-finalized-p.html
+++ b/class-finalized-p.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-finalized-p"><I>Generic Function</I> <B>CLASS-FINALIZED-P</B>

--- a/class-finalized-p.html
+++ b/class-finalized-p.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-finalized-p"><I>Generic Function</I> <B>CLASS-FINALIZED-P</B>
 

--- a/class-forward-referenced-class.html
+++ b/class-forward-referenced-class.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-forward-referenced-class.html
+++ b/class-forward-referenced-class.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>FORWARD-REFERENCED-CLASS</B>

--- a/class-funcallable-standard-class.html
+++ b/class-funcallable-standard-class.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>FUNCALLABLE-STANDARD-CLASS</B>

--- a/class-funcallable-standard-class.html
+++ b/class-funcallable-standard-class.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-funcallable-standard-object.html
+++ b/class-funcallable-standard-object.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>FUNCALLABLE-STANDARD-OBJECT</B>

--- a/class-funcallable-standard-object.html
+++ b/class-funcallable-standard-object.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-function.html
+++ b/class-function.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>FUNCTION</B>

--- a/class-function.html
+++ b/class-function.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-generic-function.html
+++ b/class-generic-function.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>GENERIC-FUNCTION</B>

--- a/class-generic-function.html
+++ b/class-generic-function.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-metaobject.html
+++ b/class-metaobject.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-metaobject.html
+++ b/class-metaobject.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>METAOBJECT</B>

--- a/class-method-combination.html
+++ b/class-method-combination.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>METHOD-COMBINATION</B>

--- a/class-method-combination.html
+++ b/class-method-combination.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-method.html
+++ b/class-method.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>METHOD</B>

--- a/class-method.html
+++ b/class-method.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-name-built-in-class.html
+++ b/class-name-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>
 

--- a/class-name-built-in-class.html
+++ b/class-name-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>

--- a/class-name-forward-referenced-class.html
+++ b/class-name-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>
 

--- a/class-name-forward-referenced-class.html
+++ b/class-name-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>

--- a/class-name-funcallable-standard-class.html
+++ b/class-name-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>
 

--- a/class-name-funcallable-standard-class.html
+++ b/class-name-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>

--- a/class-name-standard-class.html
+++ b/class-name-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>
 

--- a/class-name-standard-class.html
+++ b/class-name-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-name"><I>Method</I> <B>CLASS-NAME</B>

--- a/class-name.html
+++ b/class-name.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-name"><I>Generic Function</I> <B>CLASS-NAME</B>

--- a/class-name.html
+++ b/class-name.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-name"><I>Generic Function</I> <B>CLASS-NAME</B>
 

--- a/class-precedence-list-built-in-class.html
+++ b/class-precedence-list-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>

--- a/class-precedence-list-built-in-class.html
+++ b/class-precedence-list-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>
 

--- a/class-precedence-list-forward-referenced-class.html
+++ b/class-precedence-list-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>

--- a/class-precedence-list-forward-referenced-class.html
+++ b/class-precedence-list-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>
 

--- a/class-precedence-list-funcallable-standard-class.html
+++ b/class-precedence-list-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>

--- a/class-precedence-list-funcallable-standard-class.html
+++ b/class-precedence-list-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>
 

--- a/class-precedence-list-standard-class.html
+++ b/class-precedence-list-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>

--- a/class-precedence-list-standard-class.html
+++ b/class-precedence-list-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-precedence-list"><I>Method</I> <B>CLASS-PRECEDENCE-LIST</B>
 

--- a/class-precedence-list.html
+++ b/class-precedence-list.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-precedence-list"><I>Generic Function</I> <B>CLASS-PRECEDENCE-LIST</B>
 

--- a/class-precedence-list.html
+++ b/class-precedence-list.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-precedence-list"><I>Generic Function</I> <B>CLASS-PRECEDENCE-LIST</B>

--- a/class-prototype-built-in-class.html
+++ b/class-prototype-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>

--- a/class-prototype-built-in-class.html
+++ b/class-prototype-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>
 

--- a/class-prototype-forward-referenced-class.html
+++ b/class-prototype-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>

--- a/class-prototype-forward-referenced-class.html
+++ b/class-prototype-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>
 

--- a/class-prototype-funcallable-standard-class.html
+++ b/class-prototype-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>

--- a/class-prototype-funcallable-standard-class.html
+++ b/class-prototype-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>
 

--- a/class-prototype-standard-class.html
+++ b/class-prototype-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>

--- a/class-prototype-standard-class.html
+++ b/class-prototype-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A PROTOTYPE="class-prototype"><I>Method</I> <B>CLASS-PROTOTYPE</B>
 

--- a/class-prototype.html
+++ b/class-prototype.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-prototype"><I>Generic Function</I> <B>CLASS-PROTOTYPE</B>

--- a/class-prototype.html
+++ b/class-prototype.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-prototype"><I>Generic Function</I> <B>CLASS-PROTOTYPE</B>
 

--- a/class-slot-definition.html
+++ b/class-slot-definition.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>SLOT-DEFINITION</B>

--- a/class-slot-definition.html
+++ b/class-slot-definition.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-slots-built-in-class.html
+++ b/class-slots-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>

--- a/class-slots-built-in-class.html
+++ b/class-slots-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>
 

--- a/class-slots-forward-referenced-class.html
+++ b/class-slots-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>

--- a/class-slots-forward-referenced-class.html
+++ b/class-slots-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>
 

--- a/class-slots-funcallable-standard-class.html
+++ b/class-slots-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>

--- a/class-slots-funcallable-standard-class.html
+++ b/class-slots-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>
 

--- a/class-slots-standard-class.html
+++ b/class-slots-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>

--- a/class-slots-standard-class.html
+++ b/class-slots-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-slots"><I>Method</I> <B>CLASS-SLOTS</B>
 

--- a/class-slots.html
+++ b/class-slots.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-slots"><I>Generic Function</I> <B>CLASS-SLOTS</B>

--- a/class-slots.html
+++ b/class-slots.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-slots"><I>Generic Function</I> <B>CLASS-SLOTS</B>
 

--- a/class-specializer.html
+++ b/class-specializer.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>SPECIALIZER</B>

--- a/class-specializer.html
+++ b/class-specializer.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-accessor-method.html
+++ b/class-standard-accessor-method.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-accessor-method.html
+++ b/class-standard-accessor-method.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-ACCESSOR-METHOD</B>

--- a/class-standard-class.html
+++ b/class-standard-class.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-CLASS</B>

--- a/class-standard-class.html
+++ b/class-standard-class.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-direct-slot-definition.html
+++ b/class-standard-direct-slot-definition.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-DIRECT-SLOT-DEFINITION</B>

--- a/class-standard-direct-slot-definition.html
+++ b/class-standard-direct-slot-definition.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-effective-slot-definition.html
+++ b/class-standard-effective-slot-definition.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-EFFECTIVE-SLOT-DEFINITION</B>

--- a/class-standard-effective-slot-definition.html
+++ b/class-standard-effective-slot-definition.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-generic-function.html
+++ b/class-standard-generic-function.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-GENERIC-FUNCTION</B>

--- a/class-standard-generic-function.html
+++ b/class-standard-generic-function.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-method.html
+++ b/class-standard-method.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-METHOD</B>

--- a/class-standard-method.html
+++ b/class-standard-method.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-object.html
+++ b/class-standard-object.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-object.html
+++ b/class-standard-object.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-OBJECT</B>

--- a/class-standard-reader-method.html
+++ b/class-standard-reader-method.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-READER-METHOD</B>

--- a/class-standard-reader-method.html
+++ b/class-standard-reader-method.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-slot-definition.html
+++ b/class-standard-slot-definition.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-SLOT-DEFINITION</B>

--- a/class-standard-slot-definition.html
+++ b/class-standard-slot-definition.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-standard-writer-method.html
+++ b/class-standard-writer-method.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>STANDARD-WRITER-METHOD</B>

--- a/class-standard-writer-method.html
+++ b/class-standard-writer-method.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/class-t.html
+++ b/class-t.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
     <A NAME="t"><I>Class</I> <B>T</B>

--- a/class-t.html
+++ b/class-t.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="list-of-classes.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="list-of-classes.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/classes.html
+++ b/classes.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="slot-definitions.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Classes</H3>
 

--- a/classes.html
+++ b/classes.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="slot-definitions.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="slot-definitions.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Classes</H3>

--- a/compile-file-processing-of-the-user-interface-macros.html
+++ b/compile-file-processing-of-the-user-interface-macros.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="processing-of-the-user-interface-macros.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="processing-of-the-user-interface-macros.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="the-defclass-macro.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-of-the-user-interface-macros.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-of-the-user-interface-macros.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="the-defclass-macro.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Compile-file processing of the user interface macros</H3>

--- a/compile-file-processing-of-the-user-interface-macros.html
+++ b/compile-file-processing-of-the-user-interface-macros.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="the-defclass-macro.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Compile-file processing of the user interface macros</H3>
 

--- a/compute-applicable-methods-standard-generic-function.html
+++ b/compute-applicable-methods-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-applicable-methods"><I>Method</I> <B>COMPUTE-APPLICABLE-METHODS</B>

--- a/compute-applicable-methods-standard-generic-function.html
+++ b/compute-applicable-methods-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-applicable-methods"><I>Method</I> <B>COMPUTE-APPLICABLE-METHODS</B>
 

--- a/compute-applicable-methods-using-classes-standard-generic-function.html
+++ b/compute-applicable-methods-using-classes-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-applicable-methods-using-classes"><I>Method</I> <B>COMPUTE-APPLICABLE-METHODS-USING-CLASSES</B>

--- a/compute-applicable-methods-using-classes-standard-generic-function.html
+++ b/compute-applicable-methods-using-classes-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-applicable-methods-using-classes"><I>Method</I> <B>COMPUTE-APPLICABLE-METHODS-USING-CLASSES</B>
 

--- a/compute-applicable-methods-using-classes.html
+++ b/compute-applicable-methods-using-classes.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-applicable-methods-using-classes"><I>Generic Function</I> <B>COMPUTE-APPLICABLE-METHODS-USING-CLASSES</B>
 

--- a/compute-applicable-methods-using-classes.html
+++ b/compute-applicable-methods-using-classes.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-applicable-methods-using-classes"><I>Generic Function</I> <B>COMPUTE-APPLICABLE-METHODS-USING-CLASSES</B>

--- a/compute-applicable-methods.html
+++ b/compute-applicable-methods.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-applicable-methods"><I>Generic Function</I> <B>COMPUTE-APPLICABLE-METHODS</B>

--- a/compute-applicable-methods.html
+++ b/compute-applicable-methods.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-applicable-methods"><I>Generic Function</I> <B>COMPUTE-APPLICABLE-METHODS</B>
 

--- a/compute-class-precedence-list-class.html
+++ b/compute-class-precedence-list-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-class-precedence-list"><I>Method</I> <B>COMPUTE-CLASS-PRECEDENCE-LIST</B>

--- a/compute-class-precedence-list-class.html
+++ b/compute-class-precedence-list-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-class-precedence-list"><I>Method</I> <B>COMPUTE-CLASS-PRECEDENCE-LIST</B>
 

--- a/compute-class-precedence-list.html
+++ b/compute-class-precedence-list.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-class-precedence-list"><I>Generic Function</I> <B>COMPUTE-CLASS-PRECEDENCE-LIST</B>
 

--- a/compute-class-precedence-list.html
+++ b/compute-class-precedence-list.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-class-precedence-list"><I>Generic Function</I> <B>COMPUTE-CLASS-PRECEDENCE-LIST</B>

--- a/compute-default-initargs-funcallable-standard-class.html
+++ b/compute-default-initargs-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-default-initargs"><I>Method</I> <B>COMPUTE-DEFAULT-INITARGS</B>
 

--- a/compute-default-initargs-funcallable-standard-class.html
+++ b/compute-default-initargs-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-default-initargs"><I>Method</I> <B>COMPUTE-DEFAULT-INITARGS</B>

--- a/compute-default-initargs-standard-class.html
+++ b/compute-default-initargs-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-default-initargs"><I>Method</I> <B>COMPUTE-DEFAULT-INITARGS</B>
 

--- a/compute-default-initargs-standard-class.html
+++ b/compute-default-initargs-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-default-initargs"><I>Method</I> <B>COMPUTE-DEFAULT-INITARGS</B>

--- a/compute-default-initargs.html
+++ b/compute-default-initargs.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-default-initargs"><I>Generic Function</I> <B>COMPUTE-DEFAULT-INITARGS</B>

--- a/compute-default-initargs.html
+++ b/compute-default-initargs.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-default-initargs"><I>Generic Function</I> <B>COMPUTE-DEFAULT-INITARGS</B>
 

--- a/compute-discriminating-function-standard-generic-function.html
+++ b/compute-discriminating-function-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-discriminating-function"><I>Method</I> <B>COMPUTE-DISCRIMINATING-FUNCTION</B>

--- a/compute-discriminating-function-standard-generic-function.html
+++ b/compute-discriminating-function-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-discriminating-function"><I>Method</I> <B>COMPUTE-DISCRIMINATING-FUNCTION</B>
 

--- a/compute-discriminating-function.html
+++ b/compute-discriminating-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-discriminating-function"><I>Generic Function</I> <B>COMPUTE-DISCRIMINATING-FUNCTION</B>

--- a/compute-discriminating-function.html
+++ b/compute-discriminating-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-discriminating-function"><I>Generic Function</I> <B>COMPUTE-DISCRIMINATING-FUNCTION</B>
 

--- a/compute-effective-method-standard-generic-function.html
+++ b/compute-effective-method-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-effective-method"><I>Method</I> <B>COMPUTE-EFFECTIVE-METHOD</B>
 

--- a/compute-effective-method-standard-generic-function.html
+++ b/compute-effective-method-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-effective-method"><I>Method</I> <B>COMPUTE-EFFECTIVE-METHOD</B>

--- a/compute-effective-method.html
+++ b/compute-effective-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-effective-method"><I>Generic Function</I> <B>COMPUTE-EFFECTIVE-METHOD</B>

--- a/compute-effective-method.html
+++ b/compute-effective-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-effective-method"><I>Generic Function</I> <B>COMPUTE-EFFECTIVE-METHOD</B>
 

--- a/compute-effective-slot-definition-funcallable-standard-class.html
+++ b/compute-effective-slot-definition-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-effective-slot-definition"><I>Method</I> <B>COMPUTE-EFFECTIVE-SLOT-DEFINITION</B>

--- a/compute-effective-slot-definition-funcallable-standard-class.html
+++ b/compute-effective-slot-definition-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-effective-slot-definition"><I>Method</I> <B>COMPUTE-EFFECTIVE-SLOT-DEFINITION</B>
 

--- a/compute-effective-slot-definition-standard-class.html
+++ b/compute-effective-slot-definition-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-effective-slot-definition"><I>Method</I> <B>COMPUTE-EFFECTIVE-SLOT-DEFINITION</B>

--- a/compute-effective-slot-definition-standard-class.html
+++ b/compute-effective-slot-definition-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-effective-slot-definition"><I>Method</I> <B>COMPUTE-EFFECTIVE-SLOT-DEFINITION</B>
 

--- a/compute-effective-slot-definition.html
+++ b/compute-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-effective-slot-definition"><I>Generic Function</I>
   <B>COMPUTE-EFFECTIVE-SLOT-DEFINITION</B>

--- a/compute-effective-slot-definition.html
+++ b/compute-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-effective-slot-definition"><I>Generic Function</I>

--- a/compute-slots-around-funcallable-standard-class.html
+++ b/compute-slots-around-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-slots"><TT>:around</TT> <I>Method</I> <B>COMPUTE-SLOTS</B>

--- a/compute-slots-around-funcallable-standard-class.html
+++ b/compute-slots-around-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-slots"><TT>:around</TT> <I>Method</I> <B>COMPUTE-SLOTS</B>
 

--- a/compute-slots-around-standard-class.html
+++ b/compute-slots-around-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-slots"><TT>:around</TT> <I>Method</I> <B>COMPUTE-SLOTS</B>

--- a/compute-slots-around-standard-class.html
+++ b/compute-slots-around-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-slots"><TT>:around</TT> <I>Method</I> <B>COMPUTE-SLOTS</B>
 

--- a/compute-slots-funcallable-standard-class.html
+++ b/compute-slots-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-slots"><I>Method</I> <B>COMPUTE-SLOTS</B>
 

--- a/compute-slots-funcallable-standard-class.html
+++ b/compute-slots-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-slots"><I>Method</I> <B>COMPUTE-SLOTS</B>

--- a/compute-slots-standard-class.html
+++ b/compute-slots-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-slots"><I>Method</I> <B>COMPUTE-SLOTS</B>
 

--- a/compute-slots-standard-class.html
+++ b/compute-slots-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-slots"><I>Method</I> <B>COMPUTE-SLOTS</B>

--- a/compute-slots.html
+++ b/compute-slots.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="compute-slots"><I>Generic Function</I>

--- a/compute-slots.html
+++ b/compute-slots.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="compute-slots"><I>Generic Function</I>
   <B>COMPUTE-SLOTS</B>

--- a/dependent-maintenance-protocol.html
+++ b/dependent-maintenance-protocol.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="generic-function-invocation-protocol.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="chapter-6.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="generic-function-invocation-protocol.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Dependent maintenance protocol</H3>

--- a/dependent-maintenance-protocol.html
+++ b/dependent-maintenance-protocol.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="chapter-6.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Dependent maintenance protocol</H3>
 

--- a/direct-slot-definition-class-funcallable-standard-class.html
+++ b/direct-slot-definition-class-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="direct-slot-definition-class"><I>Method</I> <B>DIRECT-SLOT-DEFINITION-CLASS</B>

--- a/direct-slot-definition-class-funcallable-standard-class.html
+++ b/direct-slot-definition-class-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="direct-slot-definition-class"><I>Method</I> <B>DIRECT-SLOT-DEFINITION-CLASS</B>
 

--- a/direct-slot-definition-class-standard-class.html
+++ b/direct-slot-definition-class-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="direct-slot-definition-class"><I>Method</I> <B>DIRECT-SLOT-DEFINITION-CLASS</B>

--- a/direct-slot-definition-class-standard-class.html
+++ b/direct-slot-definition-class-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="direct-slot-definition-class"><I>Method</I> <B>DIRECT-SLOT-DEFINITION-CLASS</B>
 

--- a/direct-slot-definition-class.html
+++ b/direct-slot-definition-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="direct-slot-definition-class"><I>Generic Function</I> <B>DIRECT-SLOT-DEFINITION-CLASS</B>
 

--- a/direct-slot-definition-class.html
+++ b/direct-slot-definition-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="direct-slot-definition-class"><I>Generic Function</I> <B>DIRECT-SLOT-DEFINITION-CLASS</B>

--- a/effective-slot-definition-class-funcallable-standard-class.html
+++ b/effective-slot-definition-class-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="effective-slot-definition-class"><I>Method</I> <B>EFFECTIVE-SLOT-DEFINITION-CLASS</B>
 

--- a/effective-slot-definition-class-funcallable-standard-class.html
+++ b/effective-slot-definition-class-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="effective-slot-definition-class"><I>Method</I> <B>EFFECTIVE-SLOT-DEFINITION-CLASS</B>

--- a/effective-slot-definition-class-standard-class.html
+++ b/effective-slot-definition-class-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="effective-slot-definition-class"><I>Method</I> <B>EFFECTIVE-SLOT-DEFINITION-CLASS</B>
 

--- a/effective-slot-definition-class-standard-class.html
+++ b/effective-slot-definition-class-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="effective-slot-definition-class"><I>Method</I> <B>EFFECTIVE-SLOT-DEFINITION-CLASS</B>

--- a/effective-slot-definition-class.html
+++ b/effective-slot-definition-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="effective-slot-definition-class"><I>Generic Function</I> <B>EFFECTIVE-SLOT-DEFINITION-CLASS</B>

--- a/effective-slot-definition-class.html
+++ b/effective-slot-definition-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="effective-slot-definition-class"><I>Generic Function</I> <B>EFFECTIVE-SLOT-DEFINITION-CLASS</B>
 

--- a/ensure-class-using-class-class.html
+++ b/ensure-class-using-class-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-class-using-class"><I>Method</I> <B>ENSURE-CLASS-USING-CLASS</B>
 

--- a/ensure-class-using-class-class.html
+++ b/ensure-class-using-class-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-class-using-class"><I>Method</I> <B>ENSURE-CLASS-USING-CLASS</B>

--- a/ensure-class-using-class-forward-referenced-class.html
+++ b/ensure-class-using-class-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-class-using-class"><I>Method</I> <B>ENSURE-CLASS-USING-CLASS</B>
 

--- a/ensure-class-using-class-forward-referenced-class.html
+++ b/ensure-class-using-class-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-class-using-class"><I>Method</I> <B>ENSURE-CLASS-USING-CLASS</B>

--- a/ensure-class-using-class-null.html
+++ b/ensure-class-using-class-null.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-class-using-class"><I>Method</I> <B>ENSURE-CLASS-USING-CLASS</B>
 

--- a/ensure-class-using-class-null.html
+++ b/ensure-class-using-class-null.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-class-using-class"><I>Method</I> <B>ENSURE-CLASS-USING-CLASS</B>

--- a/ensure-class-using-class.html
+++ b/ensure-class-using-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-class-using-class"><I>Generic Function</I> <B>ENSURE-CLASS-USING-CLASS</B>
 

--- a/ensure-class-using-class.html
+++ b/ensure-class-using-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-class-using-class"><I>Generic Function</I> <B>ENSURE-CLASS-USING-CLASS</B>

--- a/ensure-class.html
+++ b/ensure-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-class"><I>Function</I>
   <B>ENSURE-CLASS</B>

--- a/ensure-class.html
+++ b/ensure-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-class"><I>Function</I>

--- a/ensure-generic-function-using-class-generic-function.html
+++ b/ensure-generic-function-using-class-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-generic-function-using-class"><I>Method</I> <B>ENSURE-GENERIC-FUNCTION-USING-CLASS</B>
 

--- a/ensure-generic-function-using-class-generic-function.html
+++ b/ensure-generic-function-using-class-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-generic-function-using-class"><I>Method</I> <B>ENSURE-GENERIC-FUNCTION-USING-CLASS</B>

--- a/ensure-generic-function-using-class-null.html
+++ b/ensure-generic-function-using-class-null.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-generic-function-using-class"><I>Method</I> <B>ENSURE-GENERIC-FUNCTION-USING-CLASS</B>
 

--- a/ensure-generic-function-using-class-null.html
+++ b/ensure-generic-function-using-class-null.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-generic-function-using-class"><I>Method</I> <B>ENSURE-GENERIC-FUNCTION-USING-CLASS</B>

--- a/ensure-generic-function-using-class.html
+++ b/ensure-generic-function-using-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-generic-function-using-class"><I>Generic Function</I> <B>ENSURE-GENERIC-FUNCTION-USING-CLASS</B>
 

--- a/ensure-generic-function-using-class.html
+++ b/ensure-generic-function-using-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-generic-function-using-class"><I>Generic Function</I> <B>ENSURE-GENERIC-FUNCTION-USING-CLASS</B>

--- a/ensure-generic-function.html
+++ b/ensure-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="ensure-generic-function"><I>Function</I>

--- a/ensure-generic-function.html
+++ b/ensure-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="ensure-generic-function"><I>Function</I>
   <B>ENSURE-GENERIC-FUNCTION</B>

--- a/eql-specializer-object.html
+++ b/eql-specializer-object.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="eql-specializer-object"><I>Function</I>
   <B>EQL-SPECIALIZER-OBJECT</B>

--- a/eql-specializer-object.html
+++ b/eql-specializer-object.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="eql-specializer-object"><I>Function</I>

--- a/extract-lambda-list.html
+++ b/extract-lambda-list.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="extract-lambda-list"><I>Function</I>

--- a/extract-lambda-list.html
+++ b/extract-lambda-list.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="extract-lambda-list"><I>Function</I>
   <B>EXTRACT-LAMBDA-LIST</B>

--- a/extract-specializer-names.html
+++ b/extract-specializer-names.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="extract-specializer-names"><I>Function</I>

--- a/extract-specializer-names.html
+++ b/extract-specializer-names.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="extract-specializer-names"><I>Function</I>
   <B>EXTRACT-SPECIALIZER-NAMES</B>

--- a/finalize-inheritance-forward-referenced-class.html
+++ b/finalize-inheritance-forward-referenced-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="finalize-inheritance"><I>Method</I> <B>FINALIZE-INHERITANCE</B>
 

--- a/finalize-inheritance-forward-referenced-class.html
+++ b/finalize-inheritance-forward-referenced-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="finalize-inheritance"><I>Method</I> <B>FINALIZE-INHERITANCE</B>

--- a/finalize-inheritance-funcallable-standard-class.html
+++ b/finalize-inheritance-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="finalize-inheritance"><I>Method</I> <B>FINALIZE-INHERITANCE</B>
 

--- a/finalize-inheritance-funcallable-standard-class.html
+++ b/finalize-inheritance-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="finalize-inheritance"><I>Method</I> <B>FINALIZE-INHERITANCE</B>

--- a/finalize-inheritance-standard-class.html
+++ b/finalize-inheritance-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="finalize-inheritance"><I>Method</I> <B>FINALIZE-INHERITANCE</B>
 

--- a/finalize-inheritance-standard-class.html
+++ b/finalize-inheritance-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="finalize-inheritance"><I>Method</I> <B>FINALIZE-INHERITANCE</B>

--- a/finalize-inheritance.html
+++ b/finalize-inheritance.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="finalize-inheritance"><I>Generic Function</I> <B>FINALIZE-INHERITANCE</B>

--- a/finalize-inheritance.html
+++ b/finalize-inheritance.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="finalize-inheritance"><I>Generic Function</I> <B>FINALIZE-INHERITANCE</B>
 

--- a/find-method-combination.html
+++ b/find-method-combination.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="find-method-combination"><I>Generic Function</I> <B>FIND-METHOD-COMBINATION</B>

--- a/find-method-combination.html
+++ b/find-method-combination.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="find-method-combination"><I>Generic Function</I> <B>FIND-METHOD-COMBINATION</B>
 

--- a/funcallable-instances.html
+++ b/funcallable-instances.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="instance-structure-protocol.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="generic-function-invocation-protocol.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="instance-structure-protocol.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="generic-function-invocation-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
   <H3>Funcallable Instances</H3>

--- a/funcallable-instances.html
+++ b/funcallable-instances.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="generic-function-invocation-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
   <H3>Funcallable Instances</H3>
 

--- a/funcallable-standard-instance-access.html
+++ b/funcallable-standard-instance-access.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="funcallable-standard-instance-access"><I>Function</I>

--- a/funcallable-standard-instance-access.html
+++ b/funcallable-standard-instance-access.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="funcallable-standard-instance-access"><I>Function</I>
   <B>FUNCALLABLE-STANDARD-INSTANCE-ACCESS</B>

--- a/generic-function-argument-precedence-order-standard-generic-function.html
+++ b/generic-function-argument-precedence-order-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-argument-precedence-order"><I>Method</I> <B>GENERIC-FUNCTION-ARGUMENT-PRECEDENCE-ORDER</B>

--- a/generic-function-argument-precedence-order-standard-generic-function.html
+++ b/generic-function-argument-precedence-order-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-argument-precedence-order"><I>Method</I> <B>GENERIC-FUNCTION-ARGUMENT-PRECEDENCE-ORDER</B>
 

--- a/generic-function-argument-precedence-order.html
+++ b/generic-function-argument-precedence-order.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-argument-precedence-order"><I>Generic Function</I> <B>GENERIC-FUNCTION-ARGUMENT-PRECEDENCE-ORDER</B>

--- a/generic-function-argument-precedence-order.html
+++ b/generic-function-argument-precedence-order.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-argument-precedence-order"><I>Generic Function</I> <B>GENERIC-FUNCTION-ARGUMENT-PRECEDENCE-ORDER</B>
 

--- a/generic-function-declarations-standard-generic-function.html
+++ b/generic-function-declarations-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-declarations"><I>Method</I> <B>GENERIC-FUNCTION-DECLARATIONS</B>

--- a/generic-function-declarations-standard-generic-function.html
+++ b/generic-function-declarations-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-declarations"><I>Method</I> <B>GENERIC-FUNCTION-DECLARATIONS</B>
 

--- a/generic-function-declarations.html
+++ b/generic-function-declarations.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-declarations"><I>Generic Function</I> <B>GENERIC-FUNCTION-DECLARATIONS</B>
 

--- a/generic-function-declarations.html
+++ b/generic-function-declarations.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-declarations"><I>Generic Function</I> <B>GENERIC-FUNCTION-DECLARATIONS</B>

--- a/generic-function-invocation-protocol.html
+++ b/generic-function-invocation-protocol.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="funcallable-instances.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="dependent-maintenance-protocol.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="funcallable-instances.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="dependent-maintenance-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Generic function invocation protocol</H3>

--- a/generic-function-invocation-protocol.html
+++ b/generic-function-invocation-protocol.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="dependent-maintenance-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Generic function invocation protocol</H3>
 

--- a/generic-function-lambda-list-standard-generic-function.html
+++ b/generic-function-lambda-list-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-lambda-list"><I>Method</I> <B>GENERIC-FUNCTION-LAMBDA-LIST</B>
 

--- a/generic-function-lambda-list-standard-generic-function.html
+++ b/generic-function-lambda-list-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-lambda-list"><I>Method</I> <B>GENERIC-FUNCTION-LAMBDA-LIST</B>

--- a/generic-function-lambda-list.html
+++ b/generic-function-lambda-list.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-lambda-list"><I>Generic Function</I> <B>GENERIC-FUNCTION-LAMBDA-LIST</B>

--- a/generic-function-lambda-list.html
+++ b/generic-function-lambda-list.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-lambda-list"><I>Generic Function</I> <B>GENERIC-FUNCTION-LAMBDA-LIST</B>
 

--- a/generic-function-method-class-standard-generic-function.html
+++ b/generic-function-method-class-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-method-class"><I>Method</I> <B>GENERIC-FUNCTION-METHOD-CLASS</B>

--- a/generic-function-method-class-standard-generic-function.html
+++ b/generic-function-method-class-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-method-class"><I>Method</I> <B>GENERIC-FUNCTION-METHOD-CLASS</B>
 

--- a/generic-function-method-class.html
+++ b/generic-function-method-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-method-class"><I>Generic Function</I> <B>GENERIC-FUNCTION-METHOD-CLASS</B>

--- a/generic-function-method-class.html
+++ b/generic-function-method-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-method-class"><I>Generic Function</I> <B>GENERIC-FUNCTION-METHOD-CLASS</B>
 

--- a/generic-function-method-combination-standard-generic-function.html
+++ b/generic-function-method-combination-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-method-combination"><I>Method</I> <B>GENERIC-FUNCTION-METHOD-COMBINATION</B>
 

--- a/generic-function-method-combination-standard-generic-function.html
+++ b/generic-function-method-combination-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-method-combination"><I>Method</I> <B>GENERIC-FUNCTION-METHOD-COMBINATION</B>

--- a/generic-function-method-combination.html
+++ b/generic-function-method-combination.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-method-combination"><I>Generic Function</I> <B>GENERIC-FUNCTION-METHOD-COMBINATION</B>

--- a/generic-function-method-combination.html
+++ b/generic-function-method-combination.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-method-combination"><I>Generic Function</I> <B>GENERIC-FUNCTION-METHOD-COMBINATION</B>
 

--- a/generic-function-methods-standard-generic-function.html
+++ b/generic-function-methods-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-methods"><I>Method</I> <B>GENERIC-FUNCTION-METHODS</B>

--- a/generic-function-methods-standard-generic-function.html
+++ b/generic-function-methods-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-methods"><I>Method</I> <B>GENERIC-FUNCTION-METHODS</B>
 

--- a/generic-function-methods.html
+++ b/generic-function-methods.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-methods"><I>Generic Function</I> <B>GENERIC-FUNCTION-METHODS</B>
 

--- a/generic-function-methods.html
+++ b/generic-function-methods.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-methods"><I>Generic Function</I> <B>GENERIC-FUNCTION-METHODS</B>

--- a/generic-function-name-standard-generic-function.html
+++ b/generic-function-name-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-name"><I>Method</I> <B>GENERIC-FUNCTION-NAME</B>
 

--- a/generic-function-name-standard-generic-function.html
+++ b/generic-function-name-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-name"><I>Method</I> <B>GENERIC-FUNCTION-NAME</B>

--- a/generic-function-name.html
+++ b/generic-function-name.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-name"><I>Generic Function</I> <B>GENERIC-FUNCTION-NAME</B>
 

--- a/generic-function-name.html
+++ b/generic-function-name.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-name"><I>Generic Function</I> <B>GENERIC-FUNCTION-NAME</B>

--- a/generic-functions.html
+++ b/generic-functions.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="methods.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Generic functions</H3>
 

--- a/generic-functions.html
+++ b/generic-functions.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="slot-definitions.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="methods.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="slot-definitions.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="methods.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Generic functions</H3>

--- a/implementation-and-user-specialization.html
+++ b/implementation-and-user-specialization.html
@@ -6,22 +6,18 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="inheritance-structure.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="inheritance-structure.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="restrictions-on-implementations.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="inheritance-structure.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="inheritance-structure.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="restrictions-on-implementations.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
   <H3>Implementation and User Specialization</H3>

--- a/implementation-and-user-specialization.html
+++ b/implementation-and-user-specialization.html
@@ -5,7 +5,7 @@
 </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -118,7 +118,7 @@ being executed.</li>
       Restrictions on portable programs</a>
   </li>
       
-</ul>
+</ul></nav>
 
 </BODY>
 </HTML>

--- a/implementation.html
+++ b/implementation.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="inheritance-structure.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="restrictions-on-implementations.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="inheritance-structure.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="restrictions-on-implementations.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Implementation and user specialization</H3>

--- a/implementation.html
+++ b/implementation.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="restrictions-on-implementations.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Implementation and user specialization</H3>
 

--- a/inheritance-structure.html
+++ b/inheritance-structure.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="implementation-and-user-specialization.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H2>Inheritance structure of metaobject classes</H2>
 

--- a/inheritance-structure.html
+++ b/inheritance-structure.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="method-combinations.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="implementation-and-user-specialization.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="method-combinations.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="implementation-and-user-specialization.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H2>Inheritance structure of metaobject classes</H2>

--- a/initialization-of-class-metaobjects.html
+++ b/initialization-of-class-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="metaobject-initialization-protocols.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="metaobject-initialization-protocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="reinitialization-of-class-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="metaobject-initialization-protocols.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="metaobject-initialization-protocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="reinitialization-of-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H4>Initialization of Class Metaobjects</H4>

--- a/initialization-of-class-metaobjects.html
+++ b/initialization-of-class-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="reinitialization-of-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H4>Initialization of Class Metaobjects</H4>
 

--- a/initialization-of-class-metaobjects2.html
+++ b/initialization-of-class-metaobjects2.html
@@ -4,7 +4,7 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -17,7 +17,7 @@
       <li class=navigation>
 	<a href="initialization-of-generic-function-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H3>Initialization of Class Metaobjects</H3>
 

--- a/initialization-of-class-metaobjects2.html
+++ b/initialization-of-class-metaobjects2.html
@@ -5,22 +5,18 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="initialization-of-generic-function-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-generic-function-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H3>Initialization of Class Metaobjects</H3>

--- a/initialization-of-generic-function-and-method-metaobjects.html
+++ b/initialization-of-generic-function-and-method-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="class-finalization-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H4>Initialization of generic function and method metaobjects</H4>
     

--- a/initialization-of-generic-function-and-method-metaobjects.html
+++ b/initialization-of-generic-function-and-method-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="reinitialization-of-class-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="metaobject-initialization-protocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="class-finalization-protocol.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="reinitialization-of-class-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="metaobject-initialization-protocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="class-finalization-protocol.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H4>Initialization of generic function and method metaobjects</H4>

--- a/initialization-of-generic-function-metaobjects.html
+++ b/initialization-of-generic-function-metaobjects.html
@@ -5,22 +5,18 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="initialization-of-class-metaobjects2.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="initialization-of-method-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-class-metaobjects2.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-method-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 

--- a/initialization-of-generic-function-metaobjects.html
+++ b/initialization-of-generic-function-metaobjects.html
@@ -4,7 +4,7 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -17,7 +17,7 @@
       <li class=navigation>
 	<a href="initialization-of-method-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 
 <H3>Initialization of Generic Function Metaobjects</H3>

--- a/initialization-of-method-metaobjects.html
+++ b/initialization-of-method-metaobjects.html
@@ -5,22 +5,18 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="initialization-of-generic-function-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="initialization-of-slot-definition-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-generic-function-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-slot-definition-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 

--- a/initialization-of-method-metaobjects.html
+++ b/initialization-of-method-metaobjects.html
@@ -4,7 +4,7 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -17,7 +17,7 @@
       <li class=navigation>
 	<a href="initialization-of-slot-definition-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 
 

--- a/initialization-of-slot-definition-metaobjects.html
+++ b/initialization-of-slot-definition-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -229,7 +229,7 @@ restrictions.
 	completed.
       </li>
     </ul>
-</ul>
+</ul></nav>
 
 <p>The results are undefined if any of these restrictions are
 violated.</p>

--- a/initialization-of-slot-definition-metaobjects.html
+++ b/initialization-of-slot-definition-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="initialization-of-method-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="readers-for-class-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-method-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
   <H3>Initialization of Slot Definition Metaobjects</H3>

--- a/instance-structure-protocol.html
+++ b/instance-structure-protocol.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="funcallable-instances.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
   <H3>Instance Structure Protocol</H3>
 

--- a/instance-structure-protocol.html
+++ b/instance-structure-protocol.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="class-finalization-protocol.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="funcallable-instances.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="class-finalization-protocol.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="funcallable-instances.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
   <H3>Instance Structure Protocol</H3>

--- a/intern-eql-specializer.html
+++ b/intern-eql-specializer.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="intern-eql-specializer"><I>Function</I>
   <B>INTERN-EQL-SPECIALIZER</B>

--- a/intern-eql-specializer.html
+++ b/intern-eql-specializer.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="intern-eql-specializer"><I>Function</I>

--- a/introduction.html
+++ b/introduction.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -15,7 +15,7 @@
       <li class=navigation>
 	<a href="metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H2>Introduction</H2>
     <P>

--- a/introduction.html
+++ b/introduction.html
@@ -6,18 +6,15 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H2>Introduction</H2>

--- a/list-of-classes.html
+++ b/list-of-classes.html
@@ -4,14 +4,14 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
     
     <HR>
 

--- a/list-of-classes.html
+++ b/list-of-classes.html
@@ -5,14 +5,12 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
     
     <HR>

--- a/make-instance-funcallable-standard-class.html
+++ b/make-instance-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="make-instance"><I>Method</I> <B>MAKE-INSTANCE</B>
 

--- a/make-instance-funcallable-standard-class.html
+++ b/make-instance-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="make-instance"><I>Method</I> <B>MAKE-INSTANCE</B>

--- a/make-instance-standard-class.html
+++ b/make-instance-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="make-instance"><I>Method</I> <B>MAKE-INSTANCE</B>
 

--- a/make-instance-standard-class.html
+++ b/make-instance-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="make-instance"><I>Method</I> <B>MAKE-INSTANCE</B>

--- a/make-instance-symbol.html
+++ b/make-instance-symbol.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="make-instance"><I>Method</I> <B>MAKE-INSTANCE</B>
 

--- a/make-instance-symbol.html
+++ b/make-instance-symbol.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="make-instance"><I>Method</I> <B>MAKE-INSTANCE</B>

--- a/make-instance.html
+++ b/make-instance.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="make-instance"><I>Generic Function</I> <B>MAKE-INSTANCE</B>
 

--- a/make-instance.html
+++ b/make-instance.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="make-instance"><I>Generic Function</I> <B>MAKE-INSTANCE</B>

--- a/make-method-lambda-standard-generic-function-standard-method.html
+++ b/make-method-lambda-standard-generic-function-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="make-method-lambda"><I>Method</I> <B>MAKE-METHOD-LAMBDA</B>
 

--- a/make-method-lambda-standard-generic-function-standard-method.html
+++ b/make-method-lambda-standard-generic-function-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="make-method-lambda"><I>Method</I> <B>MAKE-METHOD-LAMBDA</B>

--- a/make-method-lambda.html
+++ b/make-method-lambda.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="make-method-lambda"><I>Generic Function</I> <B>MAKE-METHOD-LAMBDA</B>

--- a/make-method-lambda.html
+++ b/make-method-lambda.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="make-method-lambda"><I>Generic Function</I> <B>MAKE-METHOD-LAMBDA</B>
 

--- a/map-dependents-funcallable-standard-class.html
+++ b/map-dependents-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="map-dependents"><I>Method</I> <B>MAP-DEPENDENTS</B>
 

--- a/map-dependents-funcallable-standard-class.html
+++ b/map-dependents-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="map-dependents"><I>Method</I> <B>MAP-DEPENDENTS</B>

--- a/map-dependents-standard-class.html
+++ b/map-dependents-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="map-dependents"><I>Method</I> <B>MAP-DEPENDENTS</B>
 

--- a/map-dependents-standard-class.html
+++ b/map-dependents-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="map-dependents"><I>Method</I> <B>MAP-DEPENDENTS</B>

--- a/map-dependents-standard-generic-function.html
+++ b/map-dependents-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="map-dependents"><I>Method</I> <B>MAP-DEPENDENTS</B>
 

--- a/map-dependents-standard-generic-function.html
+++ b/map-dependents-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="map-dependents"><I>Method</I> <B>MAP-DEPENDENTS</B>

--- a/map-dependents.html
+++ b/map-dependents.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="map-dependents"><I>Generic Function</I> <B>MAP-DEPENDENTS</B>
 

--- a/map-dependents.html
+++ b/map-dependents.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="map-dependents"><I>Generic Function</I> <B>MAP-DEPENDENTS</B>

--- a/metaobject-initialization-protocols.html
+++ b/metaobject-initialization-protocols.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="initialization-of-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Metaobject initialization protocols</H3>
 

--- a/metaobject-initialization-protocols.html
+++ b/metaobject-initialization-protocols.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="initialization-of-class-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-class-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Metaobject initialization protocols</H3>

--- a/metaobjects.html
+++ b/metaobjects.html
@@ -4,7 +4,7 @@
     <LINK rel="stylesheet" type="text/css" href="clos-mop.css">
   </HEAD>
   <BODY>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -17,7 +17,7 @@
       <li class=navigation>
 	<a href="classes.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H2>Metaobjects</H2>
 

--- a/metaobjects.html
+++ b/metaobjects.html
@@ -5,22 +5,18 @@
   </HEAD>
   <BODY>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="introduction.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="classes.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="introduction.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="classes.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H2>Metaobjects</H2>

--- a/method-combinations.html
+++ b/method-combinations.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="specializers.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="inheritance-structure.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="specializers.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="inheritance-structure.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Method combinations</H3>

--- a/method-combinations.html
+++ b/method-combinations.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="inheritance-structure.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Method combinations</H3>
 

--- a/method-function-standard-method.html
+++ b/method-function-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-function"><I>Method</I> <B>METHOD-FUNCTION</B>
 

--- a/method-function-standard-method.html
+++ b/method-function-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-function"><I>Method</I> <B>METHOD-FUNCTION</B>

--- a/method-function.html
+++ b/method-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-function"><I>Generic Function</I> <B>METHOD-FUNCTION</B>

--- a/method-function.html
+++ b/method-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-function"><I>Generic Function</I> <B>METHOD-FUNCTION</B>
 

--- a/method-generic-function-standard-method.html
+++ b/method-generic-function-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-generic-function"><I>Method</I> <B>METHOD-GENERIC-FUNCTION</B>
 

--- a/method-generic-function-standard-method.html
+++ b/method-generic-function-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-generic-function"><I>Method</I> <B>METHOD-GENERIC-FUNCTION</B>

--- a/method-generic-function.html
+++ b/method-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-generic-function"><I>Generic Function</I> <B>METHOD-GENERIC-FUNCTION</B>
 

--- a/method-generic-function.html
+++ b/method-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-generic-function"><I>Generic Function</I> <B>METHOD-GENERIC-FUNCTION</B>

--- a/method-lambda-list-standard-method.html
+++ b/method-lambda-list-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-lambda-list"><I>Method</I> <B>METHOD-LAMBDA-LIST</B>

--- a/method-lambda-list-standard-method.html
+++ b/method-lambda-list-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-lambda-list"><I>Method</I> <B>METHOD-LAMBDA-LIST</B>
 

--- a/method-lambda-list.html
+++ b/method-lambda-list.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-lambda-list"><I>Generic Function</I> <B>METHOD-LAMBDA-LIST</B>

--- a/method-lambda-list.html
+++ b/method-lambda-list.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-lambda-list"><I>Generic Function</I> <B>METHOD-LAMBDA-LIST</B>
 

--- a/method-qualifiers-standard-method.html
+++ b/method-qualifiers-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-qualifiers"><I>Method</I> <B>METHOD-QUALIFIERS</B>
 

--- a/method-qualifiers-standard-method.html
+++ b/method-qualifiers-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-qualifiers"><I>Method</I> <B>METHOD-QUALIFIERS</B>

--- a/method-qualifiers.html
+++ b/method-qualifiers.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-qualifiers"><I>Generic Function</I> <B>METHOD-QUALIFIERS</B>

--- a/method-qualifiers.html
+++ b/method-qualifiers.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-qualifiers"><I>Generic Function</I> <B>METHOD-QUALIFIERS</B>
 

--- a/method-specializers-standard-method.html
+++ b/method-specializers-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-specializers"><I>Method</I> <B>METHOD-SPECIALIZERS</B>
 

--- a/method-specializers-standard-method.html
+++ b/method-specializers-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-specializers"><I>Method</I> <B>METHOD-SPECIALIZERS</B>

--- a/method-specializers.html
+++ b/method-specializers.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="method-specializers"><I>Generic Function</I> <B>METHOD-SPECIALIZERS</B>
 

--- a/method-specializers.html
+++ b/method-specializers.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="method-specializers"><I>Generic Function</I> <B>METHOD-SPECIALIZERS</B>

--- a/methods.html
+++ b/methods.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="generic-functions.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="specializers.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="generic-functions.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="specializers.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Methods</H3>

--- a/methods.html
+++ b/methods.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="specializers.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Methods</H3>
 

--- a/processing-method-bodies.html
+++ b/processing-method-bodies.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="the-defmethod-macro.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="processing-of-the-user-interface-macros.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="the-defgeneric-macro.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="the-defmethod-macro.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-of-the-user-interface-macros.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="the-defgeneric-macro.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Processing method bodies</H3>

--- a/processing-method-bodies.html
+++ b/processing-method-bodies.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="the-defgeneric-macro.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Processing method bodies</H3>
 

--- a/processing-of-the-user-interface-macros.html
+++ b/processing-of-the-user-interface-macros.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="restrictions-on-portable-programs.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="compile-file-processing-of-the-user-interface-macros.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="restrictions-on-portable-programs.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="compile-file-processing-of-the-user-interface-macros.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H2>Processing of the user interface macros</H2>

--- a/processing-of-the-user-interface-macros.html
+++ b/processing-of-the-user-interface-macros.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="compile-file-processing-of-the-user-interface-macros.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H2>Processing of the user interface macros</H2>
 

--- a/reader-method-class-funcallable-standard-class-standard-direct-slot-definition.html
+++ b/reader-method-class-funcallable-standard-class-standard-direct-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="reader-method-class"><I>Method</I> <B>READER-METHOD-CLASS</B>
 

--- a/reader-method-class-funcallable-standard-class-standard-direct-slot-definition.html
+++ b/reader-method-class-funcallable-standard-class-standard-direct-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="reader-method-class"><I>Method</I> <B>READER-METHOD-CLASS</B>

--- a/reader-method-class-standard-class-standard-direct-slot-definition.html
+++ b/reader-method-class-standard-class-standard-direct-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="reader-method-class"><I>Method</I> <B>READER-METHOD-CLASS</B>
 

--- a/reader-method-class-standard-class-standard-direct-slot-definition.html
+++ b/reader-method-class-standard-class-standard-direct-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="reader-method-class"><I>Method</I> <B>READER-METHOD-CLASS</B>

--- a/reader-method-class.html
+++ b/reader-method-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="reader-method-class"><I>Generic Function</I> <B>READER-METHOD-CLASS</B>

--- a/reader-method-class.html
+++ b/reader-method-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="reader-method-class"><I>Generic Function</I> <B>READER-METHOD-CLASS</B>
 

--- a/readers-for-class-metaobjects.html
+++ b/readers-for-class-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="readers-for-generic-function-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H3>Readers for Class Metaobjects</H3>
 

--- a/readers-for-class-metaobjects.html
+++ b/readers-for-class-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="chapter-6.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="readers-for-generic-function-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-generic-function-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H3>Readers for Class Metaobjects</H3>

--- a/readers-for-generic-function-metaobjects.html
+++ b/readers-for-generic-function-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="readers-for-method-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H3>Readers for Generic Function Metaobjects</H3>
 

--- a/readers-for-generic-function-metaobjects.html
+++ b/readers-for-generic-function-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="readers-for-class-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="readers-for-method-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-class-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-method-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H3>Readers for Generic Function Metaobjects</H3>

--- a/readers-for-method-metaobjects.html
+++ b/readers-for-method-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="readers-for-generic-function-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="readers-for-slot-definition-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-generic-function-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-slot-definition-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H3>Readers for Method Metaobjects</H3>

--- a/readers-for-method-metaobjects.html
+++ b/readers-for-method-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="readers-for-slot-definition-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H3>Readers for Method Metaobjects</H3>
 

--- a/readers-for-slot-definition-metaobjects.html
+++ b/readers-for-slot-definition-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="all.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <H3>Readers for Slot Definition Metaobjects</H3>
 

--- a/readers-for-slot-definition-metaobjects.html
+++ b/readers-for-slot-definition-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="readers-for-method-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="chapter-6-sections.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="all.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="readers-for-method-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="chapter-6-sections.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="all.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
 <H3>Readers for Slot Definition Metaobjects</H3>

--- a/reinitialization-of-class-metaobjects.html
+++ b/reinitialization-of-class-metaobjects.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="initialization-of-generic-function-and-method-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H4>Reinitialization of Class Metaobjects</H4>
     

--- a/reinitialization-of-class-metaobjects.html
+++ b/reinitialization-of-class-metaobjects.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="initialization-of-class-metaobjects.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="metaobject-initialization-protocols.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="initialization-of-generic-function-and-method-metaobjects.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-class-metaobjects.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="metaobject-initialization-protocols.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="initialization-of-generic-function-and-method-metaobjects.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H4>Reinitialization of Class Metaobjects</H4>

--- a/remove-dependent-funcallable-standard-class.html
+++ b/remove-dependent-funcallable-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-dependent"><I>Method</I> <B>REMOVE-DEPENDENT</B>

--- a/remove-dependent-funcallable-standard-class.html
+++ b/remove-dependent-funcallable-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-dependent"><I>Method</I> <B>REMOVE-DEPENDENT</B>
 

--- a/remove-dependent-standard-class.html
+++ b/remove-dependent-standard-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-dependent"><I>Method</I> <B>REMOVE-DEPENDENT</B>

--- a/remove-dependent-standard-class.html
+++ b/remove-dependent-standard-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-dependent"><I>Method</I> <B>REMOVE-DEPENDENT</B>
 

--- a/remove-dependent-standard-generic-function.html
+++ b/remove-dependent-standard-generic-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-dependent"><I>Method</I> <B>REMOVE-DEPENDENT</B>

--- a/remove-dependent-standard-generic-function.html
+++ b/remove-dependent-standard-generic-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-dependent"><I>Method</I> <B>REMOVE-DEPENDENT</B>
 

--- a/remove-dependent.html
+++ b/remove-dependent.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-dependent"><I>Generic Function</I> <B>REMOVE-DEPENDENT</B>

--- a/remove-dependent.html
+++ b/remove-dependent.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-dependent"><I>Generic Function</I> <B>REMOVE-DEPENDENT</B>
 

--- a/remove-direct-method-class.html
+++ b/remove-direct-method-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-direct-method"><I>Method</I> <B>REMOVE-DIRECT-METHOD</B>

--- a/remove-direct-method-class.html
+++ b/remove-direct-method-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-direct-method"><I>Method</I> <B>REMOVE-DIRECT-METHOD</B>
 

--- a/remove-direct-method-eql-specializer.html
+++ b/remove-direct-method-eql-specializer.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-direct-method"><I>Method</I> <B>REMOVE-DIRECT-METHOD</B>

--- a/remove-direct-method-eql-specializer.html
+++ b/remove-direct-method-eql-specializer.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-direct-method"><I>Method</I> <B>REMOVE-DIRECT-METHOD</B>
 

--- a/remove-direct-method.html
+++ b/remove-direct-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-direct-method"><I>Generic Function</I> <B>REMOVE-DIRECT-METHOD</B>
 

--- a/remove-direct-method.html
+++ b/remove-direct-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-direct-method"><I>Generic Function</I> <B>REMOVE-DIRECT-METHOD</B>

--- a/remove-direct-subclass-class-class.html
+++ b/remove-direct-subclass-class-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-direct-subclass"><I>Method</I> <B>REMOVE-DIRECT-SUBCLASS</B>

--- a/remove-direct-subclass-class-class.html
+++ b/remove-direct-subclass-class-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-direct-subclass"><I>Method</I> <B>REMOVE-DIRECT-SUBCLASS</B>
 

--- a/remove-direct-subclass.html
+++ b/remove-direct-subclass.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-direct-subclass"><I>Generic Function</I> <B>REMOVE-DIRECT-SUBCLASS</B>

--- a/remove-direct-subclass.html
+++ b/remove-direct-subclass.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-direct-subclass"><I>Generic Function</I> <B>REMOVE-DIRECT-SUBCLASS</B>
 

--- a/remove-method-standard-generic-function-standard-method.html
+++ b/remove-method-standard-generic-function-standard-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-method"><I>Method</I> <B>REMOVE-METHOD</B>
 

--- a/remove-method-standard-generic-function-standard-method.html
+++ b/remove-method-standard-generic-function-standard-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-method"><I>Method</I> <B>REMOVE-METHOD</B>

--- a/remove-method.html
+++ b/remove-method.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="remove-method"><I>Generic Function</I> <B>REMOVE-METHOD</B>

--- a/remove-method.html
+++ b/remove-method.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="remove-method"><I>Generic Function</I> <B>REMOVE-METHOD</B>
 

--- a/restrictions-on-implementations.html
+++ b/restrictions-on-implementations.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="implementation-and-user-specialization.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="implementation-and-user-specialization.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="restrictions-on-portable-programs.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="implementation-and-user-specialization.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="implementation-and-user-specialization.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="restrictions-on-portable-programs.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H4>Restrictions on implementations</H4>

--- a/restrictions-on-implementations.html
+++ b/restrictions-on-implementations.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="restrictions-on-portable-programs.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H4>Restrictions on implementations</H4>
 

--- a/restrictions-on-portable-programs.html
+++ b/restrictions-on-portable-programs.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="processing-of-the-user-interface-macros.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H4>Restrictions on portable programs</H4>
 

--- a/restrictions-on-portable-programs.html
+++ b/restrictions-on-portable-programs.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="restrictions-on-implementations.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="implementation-and-user-specialization.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="processing-of-the-user-interface-macros.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="restrictions-on-implementations.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="implementation-and-user-specialization.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-of-the-user-interface-macros.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H4>Restrictions on portable programs</H4>

--- a/set-funcallable-instance-function.html
+++ b/set-funcallable-instance-function.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="set-funcallable-instance-function"><I>Function</I>
   <B>SET-FUNCALLABLE-INSTANCE-FUNCTION</B>

--- a/set-funcallable-instance-function.html
+++ b/set-funcallable-instance-function.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="set-funcallable-instance-function"><I>Function</I>

--- a/setf-class-name.html
+++ b/setf-class-name.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="class-name"><I>Generic Function</I> <B>(SETF CLASS-NAME)</B>
 

--- a/setf-class-name.html
+++ b/setf-class-name.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="class-name"><I>Generic Function</I> <B>(SETF CLASS-NAME)</B>

--- a/setf-generic-function-name.html
+++ b/setf-generic-function-name.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="generic-function-name"><I>Generic Function</I> <B>(SETF GENERIC-FUNCTION-NAME)</B>
 

--- a/setf-generic-function-name.html
+++ b/setf-generic-function-name.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="generic-function-name"><I>Generic Function</I> <B>(SETF GENERIC-FUNCTION-NAME)</B>

--- a/setf-slot-value-using-class-built-in-class.html
+++ b/setf-slot-value-using-class-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="setf-slot-value-using-class-built-in-class">
   <I>Method</I> <B>(SETF SLOT-DEFINITION-USING-CLASS)</B>

--- a/setf-slot-value-using-class-built-in-class.html
+++ b/setf-slot-value-using-class-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="setf-slot-value-using-class-built-in-class">

--- a/setf-slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/setf-slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="setf-slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition">

--- a/setf-slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/setf-slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="setf-slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition">
   <I>Method</I> <B>(SETF SLOT-DEFINITION-USING-CLASS)</B>

--- a/setf-slot-value-using-class-standard-class-standard-effective-slot-definition.html
+++ b/setf-slot-value-using-class-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="setf-slot-value-using-class-standard-class-standard-effective-slot-definition">

--- a/setf-slot-value-using-class-standard-class-standard-effective-slot-definition.html
+++ b/setf-slot-value-using-class-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="setf-slot-value-using-class-standard-class-standard-effective-slot-definition">
   <I>Method</I> <B>(SETF SLOT-DEFINITION-USING-CLASS)</B>

--- a/setf-slot-value-using-class.html
+++ b/setf-slot-value-using-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="setf-slot-value-using-class"><I>Generic Function</I>
   <B>(SETF SLOT-VALUE-USING-CLASS)</B>

--- a/setf-slot-value-using-class.html
+++ b/setf-slot-value-using-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="setf-slot-value-using-class"><I>Generic Function</I>

--- a/slot-boundp-using-class-built-in-class.html
+++ b/slot-boundp-using-class-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-boundp-using-class"><I>Method</I> <B>SLOT-BOUNDP-USING-CLASS</B>

--- a/slot-boundp-using-class-built-in-class.html
+++ b/slot-boundp-using-class-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-boundp-using-class"><I>Method</I> <B>SLOT-BOUNDP-USING-CLASS</B>
 

--- a/slot-boundp-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/slot-boundp-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-boundp-using-class"><I>Method</I> <B>SLOT-BOUNDP-USING-CLASS</B>

--- a/slot-boundp-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/slot-boundp-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-boundp-using-class"><I>Method</I> <B>SLOT-BOUNDP-USING-CLASS</B>
 

--- a/slot-boundp-using-class-standard-class-standard-effective-slot-definition.html
+++ b/slot-boundp-using-class-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-boundp-using-class"><I>Method</I> <B>SLOT-BOUNDP-USING-CLASS</B>

--- a/slot-boundp-using-class-standard-class-standard-effective-slot-definition.html
+++ b/slot-boundp-using-class-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-boundp-using-class"><I>Method</I> <B>SLOT-BOUNDP-USING-CLASS</B>
 

--- a/slot-boundp-using-class.html
+++ b/slot-boundp-using-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-boundp-using-class"><I>Generic Function</I> <B>SLOT-BOUNDP-USING-CLASS</B>
 

--- a/slot-boundp-using-class.html
+++ b/slot-boundp-using-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-boundp-using-class"><I>Generic Function</I> <B>SLOT-BOUNDP-USING-CLASS</B>

--- a/slot-definition-allocation-standard-slot-definition.html
+++ b/slot-definition-allocation-standard-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-allocation"><I>Method</I> <B>SLOT-DEFINITION-ALLOCATION</B>

--- a/slot-definition-allocation-standard-slot-definition.html
+++ b/slot-definition-allocation-standard-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-allocation"><I>Method</I> <B>SLOT-DEFINITION-ALLOCATION</B>
 

--- a/slot-definition-allocation.html
+++ b/slot-definition-allocation.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-allocation"><I>Generic Function</I> <B>SLOT-DEFINITION-ALLOCATION</B>
 

--- a/slot-definition-allocation.html
+++ b/slot-definition-allocation.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-allocation"><I>Generic Function</I> <B>SLOT-DEFINITION-ALLOCATION</B>

--- a/slot-definition-initargs-standard-slot-definition.html
+++ b/slot-definition-initargs-standard-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-initargs"><I>Method</I> <B>SLOT-DEFINITION-INITARGS</B>
 

--- a/slot-definition-initargs-standard-slot-definition.html
+++ b/slot-definition-initargs-standard-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-initargs"><I>Method</I> <B>SLOT-DEFINITION-INITARGS</B>

--- a/slot-definition-initargs.html
+++ b/slot-definition-initargs.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-initargs"><I>Generic Function</I> <B>SLOT-DEFINITION-INITARGS</B>

--- a/slot-definition-initargs.html
+++ b/slot-definition-initargs.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-initargs"><I>Generic Function</I> <B>SLOT-DEFINITION-INITARGS</B>
 

--- a/slot-definition-initform-standard-slot-definition.html
+++ b/slot-definition-initform-standard-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-initform"><I>Method</I> <B>SLOT-DEFINITION-INITFORM</B>

--- a/slot-definition-initform-standard-slot-definition.html
+++ b/slot-definition-initform-standard-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-initform"><I>Method</I> <B>SLOT-DEFINITION-INITFORM</B>
 

--- a/slot-definition-initform.html
+++ b/slot-definition-initform.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-initform"><I>Generic Function</I> <B>SLOT-DEFINITION-INITFORM</B>

--- a/slot-definition-initform.html
+++ b/slot-definition-initform.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-initform"><I>Generic Function</I> <B>SLOT-DEFINITION-INITFORM</B>
 

--- a/slot-definition-initfunction-standard-slot-definition.html
+++ b/slot-definition-initfunction-standard-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-initfunction"><I>Method</I> <B>SLOT-DEFINITION-INITFUNCTION</B>

--- a/slot-definition-initfunction-standard-slot-definition.html
+++ b/slot-definition-initfunction-standard-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-initfunction"><I>Method</I> <B>SLOT-DEFINITION-INITFUNCTION</B>
 

--- a/slot-definition-initfunction.html
+++ b/slot-definition-initfunction.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-initfunction"><I>Generic Function</I> <B>SLOT-DEFINITION-INITFUNCTION</B>

--- a/slot-definition-initfunction.html
+++ b/slot-definition-initfunction.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-initfunction"><I>Generic Function</I> <B>SLOT-DEFINITION-INITFUNCTION</B>
 

--- a/slot-definition-location-standard-effective-slot-definition.html
+++ b/slot-definition-location-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-location"><I>Method</I> <B>SLOT-DEFINITION-LOCATION</B>
 

--- a/slot-definition-location-standard-effective-slot-definition.html
+++ b/slot-definition-location-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-location"><I>Method</I> <B>SLOT-DEFINITION-LOCATION</B>

--- a/slot-definition-location.html
+++ b/slot-definition-location.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-location"><I>Generic Function</I> <B>SLOT-DEFINITION-LOCATION</B>
 

--- a/slot-definition-location.html
+++ b/slot-definition-location.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-location"><I>Generic Function</I> <B>SLOT-DEFINITION-LOCATION</B>

--- a/slot-definition-name-standard-slot-definition.html
+++ b/slot-definition-name-standard-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-name"><I>Method</I> <B>SLOT-DEFINITION-NAME</B>

--- a/slot-definition-name-standard-slot-definition.html
+++ b/slot-definition-name-standard-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-name"><I>Method</I> <B>SLOT-DEFINITION-NAME</B>
 

--- a/slot-definition-name.html
+++ b/slot-definition-name.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-name"><I>Generic Function</I> <B>SLOT-DEFINITION-NAME</B>

--- a/slot-definition-name.html
+++ b/slot-definition-name.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-name"><I>Generic Function</I> <B>SLOT-DEFINITION-NAME</B>
 

--- a/slot-definition-readers-standard-direct-slot-definition.html
+++ b/slot-definition-readers-standard-direct-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-readers"><I>Method</I> <B>SLOT-DEFINITION-READERS</B>
 

--- a/slot-definition-readers-standard-direct-slot-definition.html
+++ b/slot-definition-readers-standard-direct-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-readers"><I>Method</I> <B>SLOT-DEFINITION-READERS</B>

--- a/slot-definition-readers.html
+++ b/slot-definition-readers.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-readers"><I>Generic Function</I> <B>SLOT-DEFINITION-READERS</B>

--- a/slot-definition-readers.html
+++ b/slot-definition-readers.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-readers"><I>Generic Function</I> <B>SLOT-DEFINITION-READERS</B>
 

--- a/slot-definition-type-standard-slot-definition.html
+++ b/slot-definition-type-standard-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-type"><I>Method</I> <B>SLOT-DEFINITION-TYPE</B>

--- a/slot-definition-type-standard-slot-definition.html
+++ b/slot-definition-type-standard-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-type"><I>Method</I> <B>SLOT-DEFINITION-TYPE</B>
 

--- a/slot-definition-type.html
+++ b/slot-definition-type.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A TYPE="slot-definition-type"><I>Generic Function</I> <B>SLOT-DEFINITION-TYPE</B>
 

--- a/slot-definition-type.html
+++ b/slot-definition-type.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A TYPE="slot-definition-type"><I>Generic Function</I> <B>SLOT-DEFINITION-TYPE</B>

--- a/slot-definition-writers-standard-direct-slot-definition.html
+++ b/slot-definition-writers-standard-direct-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-writers"><I>Method</I> <B>SLOT-DEFINITION-WRITERS</B>
 

--- a/slot-definition-writers-standard-direct-slot-definition.html
+++ b/slot-definition-writers-standard-direct-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-writers"><I>Method</I> <B>SLOT-DEFINITION-WRITERS</B>

--- a/slot-definition-writers.html
+++ b/slot-definition-writers.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-definition-writers"><I>Generic Function</I> <B>SLOT-DEFINITION-WRITERS</B>

--- a/slot-definition-writers.html
+++ b/slot-definition-writers.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-definition-writers"><I>Generic Function</I> <B>SLOT-DEFINITION-WRITERS</B>
 

--- a/slot-definitions.html
+++ b/slot-definitions.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="classes.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="generic-functions.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="classes.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="generic-functions.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Slot definitions</H3>

--- a/slot-definitions.html
+++ b/slot-definitions.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="generic-functions.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Slot definitions</H3>
 

--- a/slot-makunbound-using-class-built-in-class.html
+++ b/slot-makunbound-using-class-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-makunbound-using-class"><I>Method</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>
 

--- a/slot-makunbound-using-class-built-in-class.html
+++ b/slot-makunbound-using-class-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-makunbound-using-class"><I>Method</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>

--- a/slot-makunbound-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/slot-makunbound-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-makunbound-using-class"><I>Method</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>
 

--- a/slot-makunbound-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/slot-makunbound-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-makunbound-using-class"><I>Method</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>

--- a/slot-makunbound-using-class-standard-class-standard-effective-slot-definition.html
+++ b/slot-makunbound-using-class-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-makunbound-using-class"><I>Method</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>
 

--- a/slot-makunbound-using-class-standard-class-standard-effective-slot-definition.html
+++ b/slot-makunbound-using-class-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-makunbound-using-class"><I>Method</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>

--- a/slot-makunbound-using-class.html
+++ b/slot-makunbound-using-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-makunbound-using-class"><I>Generic Function</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>
 

--- a/slot-makunbound-using-class.html
+++ b/slot-makunbound-using-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-makunbound-using-class"><I>Generic Function</I> <B>SLOT-MAKUNBOUND-USING-CLASS</B>

--- a/slot-value-using-class-built-in-class.html
+++ b/slot-value-using-class-built-in-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-value-using-class"><I>Method</I> <B>SLOT-VALUE-USING-CLASS</B>
 

--- a/slot-value-using-class-built-in-class.html
+++ b/slot-value-using-class-built-in-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-value-using-class"><I>Method</I> <B>SLOT-VALUE-USING-CLASS</B>

--- a/slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-value-using-class"><I>Method</I> <B>SLOT-VALUE-USING-CLASS</B>
 

--- a/slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
+++ b/slot-value-using-class-funcallable-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-value-using-class"><I>Method</I> <B>SLOT-VALUE-USING-CLASS</B>

--- a/slot-value-using-class-standard-class-standard-effective-slot-definition.html
+++ b/slot-value-using-class-standard-class-standard-effective-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-value-using-class"><I>Method</I> <B>SLOT-VALUE-USING-CLASS</B>
 

--- a/slot-value-using-class-standard-class-standard-effective-slot-definition.html
+++ b/slot-value-using-class-standard-class-standard-effective-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-value-using-class"><I>Method</I> <B>SLOT-VALUE-USING-CLASS</B>

--- a/slot-value-using-class.html
+++ b/slot-value-using-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="slot-value-using-class"><I>Generic Function</I> <B>SLOT-VALUE-USING-CLASS</B>
 

--- a/slot-value-using-class.html
+++ b/slot-value-using-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="slot-value-using-class"><I>Generic Function</I> <B>SLOT-VALUE-USING-CLASS</B>

--- a/specializer-direct-generic-functions-class.html
+++ b/specializer-direct-generic-functions-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="specializer-direct-generic-functions"><I>Method</I> <B>SPECIALIZER-DIRECT-GENERIC-FUNCTIONS</B>
 

--- a/specializer-direct-generic-functions-class.html
+++ b/specializer-direct-generic-functions-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="specializer-direct-generic-functions"><I>Method</I> <B>SPECIALIZER-DIRECT-GENERIC-FUNCTIONS</B>

--- a/specializer-direct-generic-functions-eql-specializer.html
+++ b/specializer-direct-generic-functions-eql-specializer.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="specializer-direct-generic-functions"><I>Method</I> <B>SPECIALIZER-DIRECT-GENERIC-FUNCTIONS</B>
 

--- a/specializer-direct-generic-functions-eql-specializer.html
+++ b/specializer-direct-generic-functions-eql-specializer.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="specializer-direct-generic-functions"><I>Method</I> <B>SPECIALIZER-DIRECT-GENERIC-FUNCTIONS</B>

--- a/specializer-direct-generic-functions.html
+++ b/specializer-direct-generic-functions.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="specializer-direct-generic-functions"><I>Generic Function</I> <B>SPECIALIZER-DIRECT-GENERIC-FUNCTIONS</B>

--- a/specializer-direct-generic-functions.html
+++ b/specializer-direct-generic-functions.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="specializer-direct-generic-functions"><I>Generic Function</I> <B>SPECIALIZER-DIRECT-GENERIC-FUNCTIONS</B>
 

--- a/specializer-direct-methods-class.html
+++ b/specializer-direct-methods-class.html
@@ -7,14 +7,12 @@
 
 <A NAME="specializer-direct-methods"><I>Method</I> <B>SPECIALIZER-DIRECT-METHODS</B>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 

--- a/specializer-direct-methods-class.html
+++ b/specializer-direct-methods-class.html
@@ -6,14 +6,14 @@
 <BODY>
 
 <A NAME="specializer-direct-methods"><I>Method</I> <B>SPECIALIZER-DIRECT-METHODS</B>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 
 <P><B>Syntax:</B></P>

--- a/specializer-direct-methods-eql-specializer.html
+++ b/specializer-direct-methods-eql-specializer.html
@@ -7,14 +7,12 @@
 
 <A NAME="specializer-direct-methods"><I>Method</I> <B>SPECIALIZER-DIRECT-METHODS</B>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 

--- a/specializer-direct-methods-eql-specializer.html
+++ b/specializer-direct-methods-eql-specializer.html
@@ -6,14 +6,14 @@
 <BODY>
 
 <A NAME="specializer-direct-methods"><I>Method</I> <B>SPECIALIZER-DIRECT-METHODS</B>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 
 <P><B>Syntax:</B></P>

--- a/specializer-direct-methods.html
+++ b/specializer-direct-methods.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="specializer-direct-methods"><I>Generic Function</I> <B>SPECIALIZER-DIRECT-METHODS</B>

--- a/specializer-direct-methods.html
+++ b/specializer-direct-methods.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="specializer-direct-methods"><I>Generic Function</I> <B>SPECIALIZER-DIRECT-METHODS</B>
 

--- a/specializers.html
+++ b/specializers.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="methods.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="method-combinations.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="methods.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="method-combinations.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>Specializers</H3>

--- a/specializers.html
+++ b/specializers.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="method-combinations.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>Specializers</H3>
 

--- a/standard-instance-access.html
+++ b/standard-instance-access.html
@@ -7,14 +7,12 @@
 
 <A NAME="standard-instance-access"><I>Function</I>
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
   <B>STANDARD-INSTANCE-ACCESS</B>

--- a/standard-instance-access.html
+++ b/standard-instance-access.html
@@ -6,14 +6,14 @@
 <BODY>
 
 <A NAME="standard-instance-access"><I>Function</I>
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
   <B>STANDARD-INSTANCE-ACCESS</B>
 

--- a/subprotocols.html
+++ b/subprotocols.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="metaobject-initialization-protocols.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H2>Subprotocols</H2>
 

--- a/subprotocols.html
+++ b/subprotocols.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="the-defgeneric-macro.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="table-of-contents.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="metaobject-initialization-protocols.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="the-defgeneric-macro.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="metaobject-initialization-protocols.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H2>Subprotocols</H2>

--- a/table-of-contents.html
+++ b/table-of-contents.html
@@ -1,5 +1,7 @@
 <HTML>
-<HEAD><TITLE>Table of contents</TITLE></HEAD>
+<HEAD><TITLE>Table of contents</TITLE>
+  <link rel="stylesheet" type="text/css" href="clos-mop.css">
+</HEAD>
 <BODY>
 <UL>
   <LI>Chapter 5 Concepts

--- a/the-defclass-macro.html
+++ b/the-defclass-macro.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="the-defmethod-macro.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>The <TT>defclass</TT> macro</H3>
 

--- a/the-defclass-macro.html
+++ b/the-defclass-macro.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="compile-file-processing-of-the-user-interface-macros.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="processing-of-the-user-interface-macros.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="the-defmethod-macro.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="compile-file-processing-of-the-user-interface-macros.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-of-the-user-interface-macros.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="the-defmethod-macro.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>The <TT>defclass</TT> macro</H3>

--- a/the-defgeneric-macro.html
+++ b/the-defgeneric-macro.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="subprotocols.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>The <TT>defgeneric</TT> macro</H3>
 

--- a/the-defgeneric-macro.html
+++ b/the-defgeneric-macro.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="processing-method-bodies.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="processing-of-the-user-interface-macros.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="subprotocols.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-method-bodies.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-of-the-user-interface-macros.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="subprotocols.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>The <TT>defgeneric</TT> macro</H3>

--- a/the-defmethod-macro.html
+++ b/the-defmethod-macro.html
@@ -6,22 +6,18 @@
   <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="the-defclass-macro.html" title="Prev">
-	<li class=navigation><img src="prev.png" alt="Prev">
-	</li>
-      </a>
-      <a href="processing-of-the-user-interface-macros.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
-      <a href="processing-method-bodies.html" title="Next">
-	<li class=navigation><img src="next.png" alt="Next">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="the-defclass-macro.html" title="Prev" rel="prev"><img src="prev.png" alt="Prev"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-of-the-user-interface-macros.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
+      <li class=navigation>
+	<a href="processing-method-bodies.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
+      </li>
     </ul>
 
     <H3>The <TT>defmethod</TT> macro</H3>

--- a/the-defmethod-macro.html
+++ b/the-defmethod-macro.html
@@ -5,7 +5,7 @@
   </HEAD>
   <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
@@ -18,7 +18,7 @@
       <li class=navigation>
 	<a href="processing-method-bodies.html" title="Next" rel="next"><img src="next.png" alt="Next"></a>
       </li>
-    </ul>
+    </ul></nav>
 
     <H3>The <TT>defmethod</TT> macro</H3>
 

--- a/update-dependent.html
+++ b/update-dependent.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="update-dependent"><I>Generic Function</I> <B>UPDATE-DEPENDENT</B>

--- a/update-dependent.html
+++ b/update-dependent.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="update-dependent"><I>Generic Function</I> <B>UPDATE-DEPENDENT</B>
 

--- a/validate-superclass-class-class.html
+++ b/validate-superclass-class-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="validate-superclass"><I>Method</I> <B>VALIDATE-SUPERCLASS</B>
 

--- a/validate-superclass-class-class.html
+++ b/validate-superclass-class-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="validate-superclass"><I>Method</I> <B>VALIDATE-SUPERCLASS</B>

--- a/validate-superclass.html
+++ b/validate-superclass.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="validate-superclass"><I>Generic Function</I> <B>VALIDATE-SUPERCLASS</B>
 

--- a/validate-superclass.html
+++ b/validate-superclass.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="validate-superclass"><I>Generic Function</I> <B>VALIDATE-SUPERCLASS</B>

--- a/writer-method-class-funcallable-standard-class-standard-direct-slot-definition.html
+++ b/writer-method-class-funcallable-standard-class-standard-direct-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="writer-method-class"><I>Method</I> <B>WRITER-METHOD-CLASS</B>
 

--- a/writer-method-class-funcallable-standard-class-standard-direct-slot-definition.html
+++ b/writer-method-class-funcallable-standard-class-standard-direct-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="writer-method-class"><I>Method</I> <B>WRITER-METHOD-CLASS</B>

--- a/writer-method-class-standard-class-standard-direct-slot-definition.html
+++ b/writer-method-class-standard-class-standard-direct-slot-definition.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="writer-method-class"><I>Method</I> <B>WRITER-METHOD-CLASS</B>
 

--- a/writer-method-class-standard-class-standard-direct-slot-definition.html
+++ b/writer-method-class-standard-class-standard-direct-slot-definition.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="writer-method-class"><I>Method</I> <B>WRITER-METHOD-CLASS</B>

--- a/writer-method-class.html
+++ b/writer-method-class.html
@@ -6,14 +6,12 @@
 <BODY>
 
     <ul class=navigation>
-      <a href="table-of-contents.html" title="Table of contents">
-	<li class=navigation><img src="toc.png" alt="TOC">
-	</li>
-      </a>
-      <a href="all-no-methods.html" title="Up">
-	<li class=navigation><img src="up.png" alt="Up">
-	</li>
-      </a>
+      <li class=navigation>
+	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
+      </li>
+      <li class=navigation>
+	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
+      </li>
     </ul>
 
 <A NAME="writer-method-class"><I>Generic Function</I> <B>WRITER-METHOD-CLASS</B>

--- a/writer-method-class.html
+++ b/writer-method-class.html
@@ -5,14 +5,14 @@
   </HEAD>
 <BODY>
 
-    <ul class=navigation>
+    <nav><ul class=navigation>
       <li class=navigation>
 	<a href="table-of-contents.html" title="Table of contents"><img src="toc.png" alt="TOC"></a>
       </li>
       <li class=navigation>
 	<a href="all-no-methods.html" title="Up"><img src="up.png" alt="Up"></a>
       </li>
-    </ul>
+    </ul></nav>
 
 <A NAME="writer-method-class"><I>Generic Function</I> <B>WRITER-METHOD-CLASS</B>
 


### PR DESCRIPTION
This changes the navigation links slightly so that they better conform to the HTML standards (in particular a `<ul>` may only contain `<li>` elements so we change the structure from `<ul><a><li>` to `<ul><li><a>`). We also get rid of some spurious whitespace which was causing a rendering issue. Finally we wrap all the navigation links in a `<nav>` element and add `rel` attributes to the next/prev buttons so that they may be understood better by browsers. I also added some links back to the TOC for the all functions/methods pages.

I also have some stylesheet changes in a branch of this repository which I prefer. Let me know if you want me to make a pull request for those too.